### PR TITLE
Minor improvements

### DIFF
--- a/PinKit.xcodeproj/project.pbxproj
+++ b/PinKit.xcodeproj/project.pbxproj
@@ -68,6 +68,10 @@
 		DAC5E9671EA1736A0019D5DC /* NSError+PinKit.h in Headers */ = {isa = PBXBuildFile; fileRef = DA6590681E708F6200C97DCF /* NSError+PinKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAC7D2CE1E6DFF4A008F3320 /* PNKGetRecentPostsRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = DAC7D2CC1E6DFF4A008F3320 /* PNKGetRecentPostsRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DAC7D2CF1E6DFF4A008F3320 /* PNKGetRecentPostsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = DAC7D2CD1E6DFF4A008F3320 /* PNKGetRecentPostsRequest.m */; };
+		DAE79BC41F7E48FC0090D736 /* PNKBookmarkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE79BC31F7E48FC0090D736 /* PNKBookmarkTests.m */; };
+		DAE79BC51F7E48FC0090D736 /* PNKBookmarkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE79BC31F7E48FC0090D736 /* PNKBookmarkTests.m */; };
+		DAE79BC81F7E497C0090D736 /* PNKNoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE79BC71F7E497C0090D736 /* PNKNoteTests.m */; };
+		DAE79BC91F7E497C0090D736 /* PNKNoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DAE79BC71F7E497C0090D736 /* PNKNoteTests.m */; };
 		DAF953EA1F5DC602002F317E /* RecorderSession.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAF953E91F5DC602002F317E /* RecorderSession.framework */; };
 		DAF953EC1F5DC610002F317E /* RecorderSession.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAF953EB1F5DC610002F317E /* RecorderSession.framework */; };
 		DAF953EE1F5DC6FD002F317E /* RecorderSession.framework in Copy Carthage Frameworks */ = {isa = PBXBuildFile; fileRef = DAF953EB1F5DC610002F317E /* RecorderSession.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -250,6 +254,8 @@
 		DAC5E9631EA1658F0019D5DC /* PNKHTTP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PNKHTTP.m; sourceTree = "<group>"; };
 		DAC7D2CC1E6DFF4A008F3320 /* PNKGetRecentPostsRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PNKGetRecentPostsRequest.h; sourceTree = "<group>"; };
 		DAC7D2CD1E6DFF4A008F3320 /* PNKGetRecentPostsRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PNKGetRecentPostsRequest.m; sourceTree = "<group>"; };
+		DAE79BC31F7E48FC0090D736 /* PNKBookmarkTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PNKBookmarkTests.m; sourceTree = "<group>"; };
+		DAE79BC71F7E497C0090D736 /* PNKNoteTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PNKNoteTests.m; sourceTree = "<group>"; };
 		DAE8F11F1F631C8E0085B953 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = SOURCE_ROOT; };
 		DAF953E91F5DC602002F317E /* RecorderSession.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RecorderSession.framework; path = Carthage/Build/Mac/RecorderSession.framework; sourceTree = "<group>"; };
 		DAF953EB1F5DC610002F317E /* RecorderSession.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RecorderSession.framework; path = Carthage/Build/iOS/RecorderSession.framework; sourceTree = "<group>"; };
@@ -402,6 +408,7 @@
 				DA1058F11E74B503003B5042 /* PostsTests */,
 				DA1058F51E74B503003B5042 /* TagsTests */,
 				DA1058EE1E74B503003B5042 /* NotesTests */,
+				DAE79BC61F7E49060090D736 /* TypesTests */,
 				DAFE72551EA3E38400BBF1B3 /* Supporting Files */,
 			);
 			path = PinKitTests;
@@ -517,6 +524,15 @@
 				DAF953E91F5DC602002F317E /* RecorderSession.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		DAE79BC61F7E49060090D736 /* TypesTests */ = {
+			isa = PBXGroup;
+			children = (
+				DAE79BC31F7E48FC0090D736 /* PNKBookmarkTests.m */,
+				DAE79BC71F7E497C0090D736 /* PNKNoteTests.m */,
+			);
+			path = TypesTests;
 			sourceTree = "<group>";
 		};
 		DAFE72281EA3E0CB00BBF1B3 /* Supporting Files */ = {
@@ -765,11 +781,13 @@
 				DAFE721C1EA3752300BBF1B3 /* PNKDateFormatterTests.m in Sources */,
 				DA7370D81E75855900A17C36 /* PNKGetAllPostsRequestTests.m in Sources */,
 				DA1058FA1E74B503003B5042 /* PNKGetNoteRequestTests.m in Sources */,
+				DAE79BC41F7E48FC0090D736 /* PNKBookmarkTests.m in Sources */,
 				DA1058ED1E74B4F3003B5042 /* PNKRequestTestCase.m in Sources */,
 				DA1059011E74B503003B5042 /* PNKGetTagsRequestTests.m in Sources */,
 				DAFE721E1EA378FA00BBF1B3 /* PNKMapTests.m in Sources */,
 				DA1059021E74B503003B5042 /* PNKRenameTagRequestTests.m in Sources */,
 				DA10589E1E74A92A003B5042 /* PNKAuthenticationRequestTests.m in Sources */,
+				DAE79BC81F7E497C0090D736 /* PNKNoteTests.m in Sources */,
 				DA1058FF1E74B503003B5042 /* PNKDeleteTagRequestTests.m in Sources */,
 				DA8A0CCC1E6C0E9800802315 /* PNKGetLastUpdateRequestTests.m in Sources */,
 				DA1058FD1E74B503003B5042 /* PNKDeletePostRequestTests.m in Sources */,
@@ -851,11 +869,13 @@
 				DAFE72A11EA3EBD900BBF1B3 /* PNKGetAllPostsRequestTests.m in Sources */,
 				DAFE72A71EA3EBE600BBF1B3 /* PNKGetSecretRSSKeyRequestTests.m in Sources */,
 				DAFE72A41EA3EBE000BBF1B3 /* PNKAddPostRequestTests.m in Sources */,
+				DAE79BC51F7E48FC0090D736 /* PNKBookmarkTests.m in Sources */,
 				DAFE72A21EA3EBDB00BBF1B3 /* PNKGetRecentPostsRequestTests.m in Sources */,
 				DAFE72A91EA3EBEA00BBF1B3 /* PNKAuthenticationRequestTests.m in Sources */,
 				DAFE72A51EA3EBE200BBF1B3 /* PNKMapTests.m in Sources */,
 				DAFE72A31EA3EBDD00BBF1B3 /* PNKDeletePostRequestTests.m in Sources */,
 				DAFE729D1EA3EBD100BBF1B3 /* PNKRenameTagRequestTests.m in Sources */,
+				DAE79BC91F7E497C0090D736 /* PNKNoteTests.m in Sources */,
 				DAFE72A81EA3EBE800BBF1B3 /* PNKGetLastUpdateRequestTests.m in Sources */,
 				DAFE729C1EA3EBD000BBF1B3 /* PNKGetNoteRequestTests.m in Sources */,
 				DAFE729F1EA3EBD500BBF1B3 /* PNKGetSuggestedTagsRequestTests.m in Sources */,

--- a/PinKit/PNKPinboardClient.h
+++ b/PinKit/PNKPinboardClient.h
@@ -85,6 +85,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setUsername:(NSString *)username token:(NSString *)token NS_SWIFT_NAME(set(username:token:));
 
 /**
+ Unsets the `username` and `token` values, so `authenticated` will return false.
+ */
+- (void)resetCredentials;
+
+/**
  Performs a requests against the Pinboard API.
  
  This method injects authentication credentials into the request

--- a/PinKit/PNKPinboardClient.m
+++ b/PinKit/PNKPinboardClient.m
@@ -100,6 +100,12 @@ static inline NSURL *PNKPinboardBaseURL(void);
     self.token = token;
 }
 
+- (void)resetCredentials
+{
+    self.username = nil;
+    self.token = nil;
+}
+
 - (BOOL)isAuthenticated
 {
     return (self.username != nil && self.token != nil);

--- a/PinKit/PinKitMacros.h
+++ b/PinKit/PinKitMacros.h
@@ -24,4 +24,13 @@
 
 #define fatalError(message) @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:(NSString *)(message) userInfo:nil]
 
+static inline BOOL PNKIsEqual(id _Nullable lhs, id _Nullable rhs)
+{
+    if(lhs == nil)
+    {
+        return (rhs == nil);
+    }
+    return [lhs isEqual:rhs];
+}
+
 #endif /* PINKIT_MACROS_H */

--- a/PinKit/Types/PNKBookmark.h
+++ b/PinKit/Types/PNKBookmark.h
@@ -69,6 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface PNKBookmark (PNKDictionaryRepresentable)
+@property (nonatomic, readonly) NSDictionary<NSString *, id> *dictionaryRepresentation;
 - (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dictionary;
 @end
 

--- a/PinKit/Types/PNKBookmark.h
+++ b/PinKit/Types/PNKBookmark.h
@@ -51,14 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Equality
 
 /**
- Returns a Boolean value that indicates whether the receiver and a given object are equal.
-
- @param object The object to be compared to the receiver. May be nil, in which case this method returns NO.
- @return YES if object is equal to the receiver.
- */
-- (BOOL)isEqual:(nullable id)object;
-
-/**
  Returns a Boolean value that indicates whether the receiver and the given bookmark are equal.
 
  @param bookmark A bookmark to be compared to the receiver.

--- a/PinKit/Types/PNKBookmark.h
+++ b/PinKit/Types/PNKBookmark.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A Pinboard bookmark.
  */
-@interface PNKBookmark : NSObject
+@interface PNKBookmark : NSObject <NSCopying, NSMutableCopying>
 @property (nonatomic, readonly) NSString *title;
 @property (nonatomic, readonly, nullable) NSString *descriptionText;
 @property (nonatomic, readonly) NSString *hashText;
@@ -47,6 +47,24 @@ NS_ASSUME_NONNULL_BEGIN
                           URL:(NSURL *)URL
               descriptionText:(nullable NSString *)descriptionText
                          tags:(NSArray<NSString *> *)tags;
+
+#pragma mark Equality
+
+/**
+ Returns a Boolean value that indicates whether the receiver and a given object are equal.
+
+ @param object The object to be compared to the receiver. May be nil, in which case this method returns NO.
+ @return YES if object is equal to the receiver.
+ */
+- (BOOL)isEqual:(nullable id)object;
+
+/**
+ Returns a Boolean value that indicates whether the receiver and the given bookmark are equal.
+
+ @param bookmark A bookmark to be compared to the receiver.
+ @return YES if bookmark is equal to the receiver.
+ */
+- (BOOL)isEqualToBookmark:(PNKBookmark *)bookmark;
 
 @end
 

--- a/PinKit/Types/PNKBookmark.m
+++ b/PinKit/Types/PNKBookmark.m
@@ -48,6 +48,53 @@
     return self;
 }
 
+#pragma mark - Equality
+
+- (BOOL)isEqual:(id)object
+{
+    PNKBookmark *rhs = (PNKBookmark *)object;
+    if(self == rhs)
+    {
+        return YES;
+    }
+    if(!rhs || ![rhs isKindOfClass:[self class]])
+    {
+        return NO;
+    }
+    return [self isEqualToBookmark:rhs];
+}
+
+- (BOOL)isEqualToBookmark:(PNKBookmark *)bookmark
+{
+    NSParameterAssert(bookmark);
+    
+    return [self.title isEqualToString:bookmark.title]
+        && [self.descriptionText isEqualToString:bookmark.descriptionText]
+        && [self.URL isEqual:bookmark.URL];
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return self;
+}
+
+- (id)mutableCopyWithZone:(NSZone *)zone
+{
+    PNKMutableBookmark *mutableCopy = [[PNKMutableBookmark alloc] initWithTitle:self.title
+                                                                            URL:[self.URL copy]
+                                                                descriptionText:self.descriptionText
+                                                                           tags:[self.tags copy]
+                                       ];
+    mutableCopy.hashText = self.hashText;
+    mutableCopy.meta = self.meta;
+    mutableCopy.createdAt = [self.createdAt copy];
+    mutableCopy.shared = [self isShared];
+    mutableCopy.read = [self isRead];
+    return mutableCopy;
+}
+
 @end
 
 @implementation PNKBookmark (PNKDictionaryRepresentable)

--- a/PinKit/Types/PNKBookmark.m
+++ b/PinKit/Types/PNKBookmark.m
@@ -7,6 +7,7 @@
 //
 
 #import "PNKBookmark.h"
+#import "PinKitMacros.h"
 #import "PNKPinboardBool.h"
 #import "NSDateFormatter+PNKPinboard.h"
 
@@ -70,9 +71,9 @@ static NSString * const PNKBookmarkTagsSeparator = @" ";
 {
     NSParameterAssert(bookmark);
     
-    return [self.title isEqualToString:bookmark.title]
-        && [self.descriptionText isEqualToString:bookmark.descriptionText]
-        && [self.URL isEqual:bookmark.URL];
+    return PNKIsEqual(self.title, bookmark.title)
+        && PNKIsEqual(self.URL, bookmark.URL)
+        && PNKIsEqual(self.descriptionText, bookmark.descriptionText);
 }
 
 #pragma mark - NSCopying
@@ -157,8 +158,8 @@ static NSString * const PNKBookmarkTagsSeparator = @" ";
     if(self.meta != nil) { dict[kKeyMeta] = self.meta; }
     dict[kKeyTags] = [self.tags componentsJoinedByString:PNKBookmarkTagsSeparator];
     dict[kKeyCreatedAt] = [NSDateFormatter.pnk_UTCDateFormatter stringFromDate:self.createdAt];
-    dict[kKeyShared] = @([self isShared]);
-    dict[kKeyUnread] = @(![self isRead]);
+    dict[kKeyShared] = PNKPinboardBoolStringFromBool([self isShared]);
+    dict[kKeyUnread] = PNKPinboardBoolStringFromBool(![self isRead]);
     
     return [NSDictionary dictionaryWithDictionary:dict];
 }

--- a/PinKit/Types/PNKNote.h
+++ b/PinKit/Types/PNKNote.h
@@ -10,7 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface PNKNote : NSObject
+@interface PNKNote : NSObject <NSCopying>
 @property (nonatomic, readonly) NSString *identifier;
 @property (nonatomic, readonly) NSString *title;
 @property (nonatomic, readonly) NSString *hashText;
@@ -20,6 +20,24 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *text;
 
 - (instancetype)init NS_UNAVAILABLE;
+
+#pragma mark Equality
+
+/**
+ Returns a Boolean value that indicates whether the receiver and a given object are equal.
+ 
+ @param object The object to be compared to the receiver. May be nil, in which case this method returns NO.
+ @return YES if object is equal to the receiver.
+ */
+- (BOOL)isEqual:(nullable id)object;
+
+/**
+ Returns a Boolean value that indicates whether the receiver and the given note are equal.
+ 
+ @param note A note to be compared to the receiver.
+ @return YES if note is equal to the receiver.
+ */
+- (BOOL)isEqualToNote:(PNKNote *)note;
 
 @end
 

--- a/PinKit/Types/PNKNote.h
+++ b/PinKit/Types/PNKNote.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface PNKNote (PNKDictionaryRepresentable)
+@property (nonatomic, readonly) NSDictionary<NSString *, id> *dictionaryRepresentation;
 - (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dictionary;
 @end
 

--- a/PinKit/Types/PNKNote.h
+++ b/PinKit/Types/PNKNote.h
@@ -24,14 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Equality
 
 /**
- Returns a Boolean value that indicates whether the receiver and a given object are equal.
- 
- @param object The object to be compared to the receiver. May be nil, in which case this method returns NO.
- @return YES if object is equal to the receiver.
- */
-- (BOOL)isEqual:(nullable id)object;
-
-/**
  Returns a Boolean value that indicates whether the receiver and the given note are equal.
  
  @param note A note to be compared to the receiver.

--- a/PinKit/Types/PNKNote.m
+++ b/PinKit/Types/PNKNote.m
@@ -25,18 +25,25 @@
 
 @implementation PNKNote (PNKDictionaryRepresentable)
 
+#define kKeyIdentifier @"id"
+#define kKeyTitle @"title"
+#define kKeyHash @"hash"
+#define kKeyCreatedAt @"created_at"
+#define kKeyUpdatedAt @"updated_at"
+#define kKeyLength @"length"
+#define kKeyText @"text"
+
 - (instancetype)initWithDictionary:(NSDictionary<NSString *, id> *)dictionary
 {
     NSParameterAssert(dictionary);
     
-    NSString *identifier = dictionary[@"id"];
-    NSString *title = dictionary[@"title"];
-    NSString *hashText = dictionary[@"hash"];
-    NSString *createdAtString = dictionary[@"created_at"];
-    NSString *updatedAtString = dictionary[@"updated_at"];
-    NSString *lengthString = dictionary[@"length"];
-    
-    NSString *text = dictionary[@"text"];
+    NSString *identifier = dictionary[kKeyIdentifier];
+    NSString *title = dictionary[kKeyTitle];
+    NSString *hashText = dictionary[kKeyHash];
+    NSString *createdAtString = dictionary[kKeyCreatedAt];
+    NSString *updatedAtString = dictionary[kKeyUpdatedAt];
+    NSString *lengthString = dictionary[kKeyLength];
+    NSString *text = dictionary[kKeyText];
     
     NSDateFormatter *dateFormatter = NSDateFormatter.pnk_notesDateFormatter;
     
@@ -50,6 +57,22 @@
     note.text = text;
     
     return note;
+}
+
+- (NSDictionary<NSString *,id> *)dictionaryRepresentation
+{
+    NSMutableDictionary *dict = [NSMutableDictionary new];
+    dict[kKeyIdentifier] = self.identifier;
+    dict[kKeyTitle] = self.title;
+    dict[kKeyHash] = self.hashText;
+    
+    NSDateFormatter *dateFormatter = NSDateFormatter.pnk_notesDateFormatter;
+    dict[kKeyCreatedAt] = [dateFormatter stringFromDate:self.createdAt];
+    dict[kKeyUpdatedAt] = [dateFormatter stringFromDate:self.updatedAt];
+    dict[kKeyLength] = @(self.length);
+    dict[kKeyText] = self.text;
+    
+    return [NSDictionary dictionaryWithDictionary:dict];
 }
 
 @end

--- a/PinKit/Types/PNKNote.m
+++ b/PinKit/Types/PNKNote.m
@@ -7,6 +7,7 @@
 //
 
 #import "PNKNote.h"
+#import "PinKitMacros.h"
 #import "NSDateFormatter+PNKPinboard.h"
 
 @interface PNKNote ()
@@ -21,6 +22,43 @@
 @end
 
 @implementation PNKNote
+
+#pragma mark - Equality
+
+- (BOOL)isEqual:(id)object
+{
+    PNKNote *rhs = (PNKNote *)object;
+    if(self == rhs)
+    {
+        return YES;
+    }
+    if(!rhs || ![rhs isKindOfClass:[self class]])
+    {
+        return NO;
+    }
+    return [self isEqualToNote:rhs];
+}
+
+- (BOOL)isEqualToNote:(PNKNote *)note
+{
+    NSParameterAssert(note);
+    
+    return PNKIsEqual(self.identifier, note.identifier)
+        && PNKIsEqual(self.title, note.title)
+        && PNKIsEqual(self.hashText, note.hashText)
+        && PNKIsEqual(self.createdAt, note.createdAt)
+        && PNKIsEqual(self.updatedAt, note.updatedAt)
+        && self.length == note.length
+        && PNKIsEqual(self.text, note.text);
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return self;
+}
+
 @end
 
 @implementation PNKNote (PNKDictionaryRepresentable)

--- a/PinKitTests/PNKPinboardClientTests.m
+++ b/PinKitTests/PNKPinboardClientTests.m
@@ -49,6 +49,19 @@
     XCTAssertTrue([self.client isAuthenticated]);
 }
 
+- (void)testResetCredentials
+{
+    NSString *username = @"token";
+    NSString *token = @"username";
+    [self.client setUsername:username token:token];
+    XCTAssertTrue([self.client isAuthenticated]);
+    
+    [self.client resetCredentials];
+    XCTAssertFalse([self.client isAuthenticated]);
+    XCTAssertNil(self.client.username);
+    XCTAssertNil(self.client.token);
+}
+
 - (void)testAuthenticationToken
 {
     XCTAssertNil([self.client performSelector:@selector(authenticationToken)]);  // test the private implementation

--- a/PinKitTests/TypesTests/PNKBookmarkTests.m
+++ b/PinKitTests/TypesTests/PNKBookmarkTests.m
@@ -1,0 +1,79 @@
+//
+//  PNKBookmarkTests.m
+//  PinKit
+//
+//  Created by Marcel Dierkes on 29.09.17.
+//  Copyright © 2017 Marcel Dierkes. All rights reserved.
+//
+
+@import XCTest;
+@import PinKit;
+
+@interface PNKBookmarkTests : XCTestCase
+@end
+
+@implementation PNKBookmarkTests
+
+- (void)testEquality
+{
+    PNKBookmark *bk1 = [[PNKBookmark alloc] initWithTitle:@"Test Bookmark"
+                                                      URL:[NSURL URLWithString:@"http://example.com/test"]
+                                          descriptionText:nil
+                                                     tags:@[]
+                        ];
+    PNKBookmark *bk2 = [[PNKBookmark alloc] initWithTitle:@"Test Bookmark"
+                                                      URL:[NSURL URLWithString:@"http://example.com/test"]
+                                          descriptionText:@"A description text"
+                                                     tags:@[]
+                        ];
+    PNKBookmark *bk3 = [[PNKBookmark alloc] initWithTitle:@"Test Bookmark"
+                                                      URL:[NSURL URLWithString:@"http://example.com/test"]
+                                          descriptionText:nil
+                                                     tags:@[]
+                        ];
+    
+    XCTAssertFalse([bk1 isEqual:@6]);
+    XCTAssertFalse([bk1 isEqual:nil]);
+    XCTAssertFalse([bk1 isEqual:bk2]);
+    XCTAssertTrue([bk1 isEqual:bk3]);
+    XCTAssertTrue([bk1 isEqual:bk1]);
+    XCTAssertTrue([bk1 isEqual:[bk1 mutableCopy]]);
+}
+
+- (void)testCopyWithZone
+{
+    PNKBookmark *bookmark = [[PNKBookmark alloc] initWithTitle:@"Test Bookmark"
+                                                      URL:[NSURL URLWithString:@"http://example.com/test"]
+                                          descriptionText:nil
+                                                     tags:@[]
+                        ];
+    XCTAssertTrue(bookmark == [bookmark copy]);
+}
+
+- (void)testDictionaryRepresentation
+{
+    __auto_type bookmark = [[PNKMutableBookmark alloc] initWithTitle:@"Test Bookmark"
+                                                                 URL:[NSURL URLWithString:@"http://example.com/test"]
+                                                     descriptionText:@"A handy test bookmark."
+                                                                tags:@[@"test", @"bookmark", @"unit-testing"]
+                            ];
+    bookmark.createdAt = [NSDate dateWithTimeIntervalSince1970:10];
+    bookmark.shared = NO;
+    NSDictionary *dict = [bookmark dictionaryRepresentation];
+    
+    NSDictionary *expectedDict = @{
+                                   @"description": @"Test Bookmark",
+                                   @"extended": @"A handy test bookmark.",
+                                   @"href": @"http://example.com/test",
+                                   @"shared": @"no",
+                                   @"tags": @"test bookmark unit-testing",
+                                   @"time": @"1970-01-01T00:00:10Z",
+                                   @"toread": @"yes"
+                                   };
+    XCTAssertEqualObjects(dict, expectedDict);
+    
+    PNKBookmark *expectedBookmark = [[PNKBookmark alloc] initWithDictionary:dict];
+    XCTAssertTrue([bookmark isEqualToBookmark:expectedBookmark]);
+}
+
+@end

--- a/PinKitTests/TypesTests/PNKNoteTests.m
+++ b/PinKitTests/TypesTests/PNKNoteTests.m
@@ -1,0 +1,62 @@
+//
+//  PNKNoteTests.m
+//  PinKit
+//
+//  Created by Marcel Dierkes on 29.09.17.
+//  Copyright © 2017 Marcel Dierkes. All rights reserved.
+//
+
+@import XCTest;
+@import PinKit;
+
+@interface PNKNoteTests : XCTestCase
+@end
+
+@implementation PNKNoteTests
+
+- (void)testEquality
+{
+    NSDictionary *noteDict1 = @{
+                                @"length": @666,
+                                @"hash": @"cb2bfe8b43362eb5b56b",
+                                @"id": @"c2f024f1eda0f199bfca",
+                                @"created_at": @"2018-02-14 18:42:22",
+                                @"title": @"Testnote",
+                                @"text": @"Lorem ipsum dolor sit amet.",
+                                @"updated_at": @"2018-02-14 18:42:22"
+                                };
+    PNKNote *note1 = [[PNKNote alloc] initWithDictionary:noteDict1];
+    NSDictionary *noteDict2 = @{
+                                @"length": @333,
+                                @"hash": @"cb2bfe8b43362eb5b5a8",
+                                @"id": @"c2f024f1eda0f199bfff",
+                                @"created_at": @"2017-02-14 10:10:10",
+                                @"title": @"Some random note",
+                                @"text": @"Hello World",
+                                @"updated_at": @"2017-02-14 10:10:10"
+                                };
+    PNKNote *note2 = [[PNKNote alloc] initWithDictionary:noteDict2];
+    PNKNote *note3 = [[PNKNote alloc] initWithDictionary:noteDict1];
+    
+    XCTAssertFalse([note1 isEqual:@1]);
+    XCTAssertFalse([note1 isEqual:note2]);
+    XCTAssertTrue([note1 isEqual:[note1 copy]]);
+    XCTAssertTrue([note1 isEqual:note3]);
+}
+
+- (void)testDictionaryRepresentation
+{
+    NSDictionary *noteDict1 = @{
+                                @"length": @666,
+                                @"hash": @"cb2bfe8b43362eb5b56b",
+                                @"id": @"c2f024f1eda0f199bfca",
+                                @"created_at": @"2018-02-14 18:42:22",
+                                @"title": @"Testnote",
+                                @"text": @"Lorem ipsum dolor sit amet.",
+                                @"updated_at": @"2015-02-14 18:42:22"
+                                };
+    PNKNote *note1 = [[PNKNote alloc] initWithDictionary:noteDict1];
+    XCTAssertEqualObjects(note1.dictionaryRepresentation, noteDict1);
+}
+
+@end


### PR DESCRIPTION
- added `removeCredentials` method
- PNKNote and PNKBookmark are now:
    - equatable
    - NSCopying-compliant
    - fully dictionary serializable/deserializable
